### PR TITLE
feat: align CreateEmailRequest with actual Sendly API

### DIFF
--- a/tessera_sdk/sendly/client.py
+++ b/tessera_sdk/sendly/client.py
@@ -71,14 +71,11 @@ class SendlyClient(BaseClient):
             >>> from tessera_sdk.sendly.schemas import CreateEmailRequest
             >>> client = SendlyClient(base_url="https://sendly.example.com", api_token="your-token")
             >>> request = CreateEmailRequest(
-            ...     name="Welcome Email",
             ...     project_id="a0ca28dc-b064-43b7-90c4-208031508397",
-            ...     provider="provider-456",
             ...     from_email="noreply@example.com",
             ...     subject="Welcome!",
-            ...     html="<html><body>Hello ${name}!</body></html>",
+            ...     html="<html><body>Hello!</body></html>",
             ...     to=["user@example.com"],
-            ...     template_variables={"name": "John"}
             ... )
             >>> response = client.create_email(request)
             >>> print(response.status)  # 'sent'

--- a/tessera_sdk/sendly/schemas/__init__.py
+++ b/tessera_sdk/sendly/schemas/__init__.py
@@ -2,11 +2,10 @@
 Sendly schemas module.
 """
 
-from .create_email_request import CreateEmailRequest, TemplateVariables
+from .create_email_request import CreateEmailRequest
 from .create_email_response import CreateEmailResponse
 
 __all__ = [
     "CreateEmailRequest",
-    "TemplateVariables",
     "CreateEmailResponse",
 ]

--- a/tessera_sdk/sendly/schemas/create_email_request.py
+++ b/tessera_sdk/sendly/schemas/create_email_request.py
@@ -1,35 +1,59 @@
-from pydantic import BaseModel, Field
-from typing import List, Dict, Any
+from pydantic import BaseModel, EmailStr, Field
+from typing import Any, Dict, List, Optional
+from uuid import UUID
 
 
-class TemplateVariables(BaseModel):
-    """Schema for template variables."""
+class Attachment(BaseModel):
+    """Email attachment."""
 
-    model_config = {"from_attributes": True}
+    filename: str
+    content_bytes_b64: str
+    mime_type: str = "application/octet-stream"
 
 
 class CreateEmailRequest(BaseModel):
-    """Schema for send email request."""
+    """Schema for creating an email."""
 
-    name: str
-    """Name/identifier for the email."""
-
-    project_id: str
+    project_id: Optional[UUID] = None
     """Project identifier."""
 
-    from_email: str
-    """Sender email address."""
+    from_email: Optional[EmailStr] = None
+    """Sender email address. Falls back to Sendly's configured default if not provided."""
 
     subject: str
     """Email subject line."""
 
-    html: str
+    html: Optional[str] = None
     """HTML content of the email."""
 
-    to: List[str]
+    text: Optional[str] = None
+    """Plain text content of the email."""
+
+    to: List[EmailStr]
     """List of recipient email addresses."""
 
+    cc: List[EmailStr] = Field(default_factory=list)
+    """CC recipients."""
+
+    bcc: List[EmailStr] = Field(default_factory=list)
+    """BCC recipients."""
+
+    attachments: List[Attachment] = Field(default_factory=list)
+    """File attachments."""
+
+    template_id: Optional[str] = None
+    """Template identifier for templated emails."""
+
     template_variables: Dict[str, Any] = Field(default_factory=dict)
-    """Variables to be replaced in the email template."""
+    """Variables to substitute in the email template."""
+
+    custom_headers: Dict[str, str] = Field(default_factory=dict)
+    """Custom email headers."""
+
+    priority: Optional[int] = None
+    """Email priority level."""
+
+    idempotency_key: Optional[str] = None
+    """Optional key to deduplicate client retries."""
 
     model_config = {"from_attributes": True}

--- a/tests/clients/test_clients.py
+++ b/tests/clients/test_clients.py
@@ -151,11 +151,10 @@ def test_quore_maps_validation_errors():
 
 def test_sendly_create_email_uses_payload():
     request = CreateEmailRequest(
-        name="Welcome",
-        project_id="tenant-1",
+        project_id="7ffd064b-27c0-4a87-8065-46af46852db8",
         from_email="noreply@example.com",
         subject="Welcome!",
-        html="<p>Hello</p>",
+        html="<p>Hello ${name}!</p>",
         to=["user@example.com"],
         template_variables={"name": "Ada"},
     )
@@ -163,11 +162,11 @@ def test_sendly_create_email_uses_payload():
         "from_email": "noreply@example.com",
         "to_email": "user@example.com",
         "subject": "Welcome!",
-        "body": "<p>Hello</p>",
+        "body": "<p>Hello Ada!</p>",
         "status": "sent",
         "provider": "provider-1",
         "provider_message_id": "message-1",
-        "project_id": "tenant-1",
+        "project_id": "7ffd064b-27c0-4a87-8065-46af46852db8",
         "id": "email-1",
     }
     client = SendlyClient(base_url="https://sendly.example.com")


### PR DESCRIPTION
## Summary

- Removes the `name` field (not part of the Sendly API)
- Makes `from_email`, `project_id`, and `html` optional (Sendly has defaults/alternatives)
- Adds missing fields: `text`, `cc`, `bcc`, `attachments`, `template_id`, `custom_headers`, `priority`, `idempotency_key`
- Adds `Attachment` model matching the Sendly provider schema

## Test plan

- [ ] Verify existing `SendlyClient.create_email()` calls still work with updated schema
- [ ] Confirm optional fields serialize correctly (omitted when `None`)
- [ ] Test `Attachment` model with base64-encoded content

🤖 Generated with [Claude Code](https://claude.com/claude-code)