### PR TITLE
Add SendlyClient.list_emails and broadcast delivery-outcome counts

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "tessera-sdk"
-version = "0.1.4"
+version = "0.1.5"
 description = "A Python SDK for Tessera with Identies integration, authentication middleware, and user onboarding"
 authors = ["ejankowski@gmail.com"]
 license = "MIT"

--- a/tessera_sdk/clients/sendly/client.py
+++ b/tessera_sdk/clients/sendly/client.py
@@ -3,7 +3,7 @@ Main Sendly client for interacting with the Sendly API.
 """
 
 import logging
-from typing import Optional
+from typing import Any, Dict, Optional
 import requests
 
 from .._base.client import BaseClient
@@ -121,3 +121,43 @@ class SendlyClient(BaseClient):
 
         response = self._make_request(HTTPMethods.GET, endpoint, params=params)
         return GetBroadcastResponse(**response.json())
+
+    def list_emails(
+        self,
+        project_id: Optional[str] = None,
+        batch_id: Optional[str] = None,
+        tag: Optional[str] = None,
+        status: Optional[str] = None,
+        page: int = 1,
+        size: int = 50,
+    ) -> Dict[str, Any]:
+        """
+        List emails, optionally filtered by project, broadcast batch, tag,
+        or status (paginated).
+
+        For example, to find who opened a given broadcast:
+        list_emails(batch_id=batch_id, status="opened").
+
+        Args:
+            project_id: Optional project ID to filter emails by.
+            batch_id: Optional broadcast batch_id to filter emails by.
+            tag: Optional exact tag membership filter.
+            status: Optional email status filter (e.g. 'opened', 'delivered').
+            page: Page number (1-based).
+            size: Number of items per page.
+
+        Returns:
+            Paginated response dict with items and pagination metadata.
+        """
+        params = {
+            "project_id": project_id,
+            "batch_id": batch_id,
+            "tag": tag,
+            "status": status,
+            "page": page,
+            "size": size,
+        }
+        params = {key: value for key, value in params.items() if value is not None}
+
+        response = self._make_request(HTTPMethods.GET, "/emails", params=params)
+        return response.json()

--- a/tessera_sdk/clients/sendly/schemas/get_broadcast_response.py
+++ b/tessera_sdk/clients/sendly/schemas/get_broadcast_response.py
@@ -19,3 +19,17 @@ class GetBroadcastResponse(BaseModel):
     finished: bool
     """True once the send stage has been attempted for every queued recipient.
     Does not track post-send webhook updates (opened/clicked/bounced, etc.)."""
+
+    delivered_count: int
+    """Number of recipient emails that have ever reached 'delivered' status."""
+
+    bounced_count: int
+    """Number of recipient emails that have ever reached 'bounced' status."""
+
+    complained_count: int
+    """Number of recipient emails that have ever reached 'complained' status."""
+
+    opened_count: int
+    """Number of recipient emails that have ever reached 'opened' status.
+    Approximate: a Click webhook arriving before its Open webhook for the
+    same email can skip past 'opened', causing a rare undercount."""

--- a/tests/clients/test_clients.py
+++ b/tests/clients/test_clients.py
@@ -276,6 +276,10 @@ def test_sendly_get_broadcast_returns_status():
         "suppressed_count": 0,
         "prepared_count": 2,
         "finished": True,
+        "delivered_count": 2,
+        "bounced_count": 0,
+        "complained_count": 0,
+        "opened_count": 1,
     }
     client = SendlyClient(base_url="https://sendly.example.com")
 
@@ -291,6 +295,10 @@ def test_sendly_get_broadcast_returns_status():
     )
     assert result.finished is True
     assert result.prepared_count == 2
+    assert result.delivered_count == 2
+    assert result.bounced_count == 0
+    assert result.complained_count == 0
+    assert result.opened_count == 1
 
 
 def test_sendly_get_broadcast_passes_project_id_as_query_param():
@@ -300,6 +308,10 @@ def test_sendly_get_broadcast_passes_project_id_as_query_param():
         "suppressed_count": 0,
         "prepared_count": 0,
         "finished": False,
+        "delivered_count": 0,
+        "bounced_count": 0,
+        "complained_count": 0,
+        "opened_count": 0,
     }
     client = SendlyClient(base_url="https://sendly.example.com")
 
@@ -329,6 +341,94 @@ def test_sendly_get_broadcast_maps_not_found_errors():
     ):
         with pytest.raises(TesseraNotFoundError):
             client.get_broadcast("does-not-exist")
+
+
+def test_sendly_list_emails_defaults_to_page_one():
+    payload = {
+        "items": [{"id": "email-1", "status": "opened"}],
+        "page": 1,
+        "size": 50,
+        "total": 1,
+        "pages": 1,
+    }
+    client = SendlyClient(base_url="https://sendly.example.com")
+
+    with patch.object(
+        SendlyClient, "_make_request", return_value=DummyResponse(payload)
+    ) as mock_request:
+        result = client.list_emails()
+
+    mock_request.assert_called_once_with(
+        HTTPMethods.GET,
+        "/emails",
+        params={"page": 1, "size": 50},
+    )
+    assert result == payload
+
+
+def test_sendly_list_emails_filters_by_batch_id_and_status():
+    payload = {"items": [], "page": 1, "size": 50, "total": 0, "pages": 0}
+    client = SendlyClient(base_url="https://sendly.example.com")
+
+    with patch.object(
+        SendlyClient, "_make_request", return_value=DummyResponse(payload)
+    ) as mock_request:
+        client.list_emails(
+            batch_id="b3f1c1d2-27c0-4a87-8065-46af46852db8", status="opened"
+        )
+
+    mock_request.assert_called_once_with(
+        HTTPMethods.GET,
+        "/emails",
+        params={
+            "batch_id": "b3f1c1d2-27c0-4a87-8065-46af46852db8",
+            "status": "opened",
+            "page": 1,
+            "size": 50,
+        },
+    )
+
+
+def test_sendly_list_emails_passes_all_filters_and_pagination():
+    payload = {"items": [], "page": 2, "size": 10, "total": 0, "pages": 0}
+    client = SendlyClient(base_url="https://sendly.example.com")
+
+    with patch.object(
+        SendlyClient, "_make_request", return_value=DummyResponse(payload)
+    ) as mock_request:
+        client.list_emails(
+            project_id="proj-42",
+            batch_id="batch-1",
+            tag="campaign-x",
+            status="delivered",
+            page=2,
+            size=10,
+        )
+
+    mock_request.assert_called_once_with(
+        HTTPMethods.GET,
+        "/emails",
+        params={
+            "project_id": "proj-42",
+            "batch_id": "batch-1",
+            "tag": "campaign-x",
+            "status": "delivered",
+            "page": 2,
+            "size": 10,
+        },
+    )
+
+
+def test_sendly_list_emails_maps_auth_errors():
+    client = SendlyClient(base_url="https://sendly.example.com")
+
+    with patch.object(
+        SendlyClient,
+        "_make_request",
+        side_effect=TesseraAuthenticationError("nope"),
+    ):
+        with pytest.raises(TesseraAuthenticationError):
+            client.list_emails()
 
 
 def test_vaulta_get_asset_returns_response():


### PR DESCRIPTION
## Summary
- Add `SendlyClient.list_emails(project_id, batch_id, tag, status, page, size)`, wired to `GET /emails` on the Sendly API (tesserahq/sendly#101), which now supports a `status` filter — e.g. `list_emails(batch_id=batch_id, status="opened")` to find who opened a broadcast.
- Add `delivered_count`, `bounced_count`, `complained_count`, `opened_count` to `GetBroadcastResponse`, matching the fields Sendly's `GET /broadcasts/{batch_id}` now returns.
- Bump SDK version 0.1.4 → 0.1.5.

## Test plan
- [x] `poetry run pytest tests/clients/test_clients.py -k sendly -v` — all 10 sendly tests pass, including new `list_emails` coverage (defaults, filters, pagination, error mapping) and updated `get_broadcast` payloads with the new counter fields

🤖 Generated with [Claude Code](https://claude.com/claude-code)