### PR TITLE
Add async streaming method to ModelaClient

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -30,7 +30,7 @@ version = "4.14.2"
 description = "High-level concurrency and networking framework on top of asyncio or Trio"
 optional = false
 python-versions = ">=3.10"
-groups = ["main", "dev"]
+groups = ["main"]
 files = [
     {file = "anyio-4.14.2-py3-none-any.whl", hash = "sha256:9f505dda5ac9f0c8309b5e8bd445a8c2bf7246f3ce950121e45ea15bc41d1494"},
     {file = "anyio-4.14.2.tar.gz", hash = "sha256:cfa139f3ed1a23ee8f88a145ddb5ac7605b8bbfd8592baacd7ce3d8bb4313c7f"},
@@ -157,7 +157,7 @@ version = "2026.7.22"
 description = "Python package for providing Mozilla's CA Bundle."
 optional = false
 python-versions = ">=3.7"
-groups = ["main", "dev"]
+groups = ["main"]
 files = [
     {file = "certifi-2026.7.22-py3-none-any.whl", hash = "sha256:62f22742b58a1a33014a2b6b706588a8d7e2a88ae7bd1a6ebe8c992928483775"},
     {file = "certifi-2026.7.22.tar.gz", hash = "sha256:741e2c3b351ddf169a738da9f2c048608ff7f2c5cc02f1ebc6b118bb090d5d55"},
@@ -785,7 +785,7 @@ version = "0.16.0"
 description = "A pure-Python, bring-your-own-I/O implementation of HTTP/1.1"
 optional = false
 python-versions = ">=3.8"
-groups = ["dev"]
+groups = ["main"]
 files = [
     {file = "h11-0.16.0-py3-none-any.whl", hash = "sha256:63cf8bbe7522de3bf65932fda1d9c2772064ffb3dae62d55932da54b31cb6c86"},
     {file = "h11-0.16.0.tar.gz", hash = "sha256:4e35b956cf45792e4caa5885e69fba00bdbc6ffafbfa020300e549b208ee5ff1"},
@@ -797,7 +797,7 @@ version = "1.0.9"
 description = "A minimal low-level HTTP client."
 optional = false
 python-versions = ">=3.8"
-groups = ["dev"]
+groups = ["main"]
 files = [
     {file = "httpcore-1.0.9-py3-none-any.whl", hash = "sha256:2d400746a40668fc9dec9810239072b40b4484b640a8c38fd654a024c7a1bf55"},
     {file = "httpcore-1.0.9.tar.gz", hash = "sha256:6e34463af53fd2ab5d807f399a9b45ea31c3dfa2276f15a2c3f00afff6e176e8"},
@@ -819,7 +819,7 @@ version = "0.28.1"
 description = "The next generation HTTP client."
 optional = false
 python-versions = ">=3.8"
-groups = ["dev"]
+groups = ["main"]
 files = [
     {file = "httpx-0.28.1-py3-none-any.whl", hash = "sha256:d909fcccc110f8c7faf814ca82a9a4d816bc5a6dbfea25d6591d6985b8ba59ad"},
     {file = "httpx-0.28.1.tar.gz", hash = "sha256:75e98c5f16b0f35b567856f597f06ff2270a374470a5c2392242528e3e3e42fc"},
@@ -844,7 +844,7 @@ version = "3.18"
 description = "Internationalized Domain Names in Applications (IDNA)"
 optional = false
 python-versions = ">=3.9"
-groups = ["main", "dev"]
+groups = ["main"]
 files = [
     {file = "idna-3.18-py3-none-any.whl", hash = "sha256:7f952cbe720b688055e3f87de14f5c3e5fdaa8bc3928985c4077ca689de849a2"},
     {file = "idna-3.18.tar.gz", hash = "sha256:ffb385a7e039654cef1ab9ef32c6fafe283c0c0467bba1d9029738ce4a14a848"},
@@ -2033,4 +2033,4 @@ dev = ["pytest", "setuptools"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.11"
-content-hash = "2b6468591399d606297b524fe27df0bd1c6bca1c65ca9f3093bccdd3893f7f4d"
+content-hash = "85bb4eb1470ecd34d1e1f5073d283996f76a87a68ced1b54b289816cf0045ad3"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,7 @@ packages = [
 [tool.poetry.dependencies]
 python = ">=3.11"
 requests = ">=2.25.0"
+httpx = "^0.28.1"
 pydantic = {extras = ["email"], version = "^2.12.4"}
 urllib3 = ">=1.26.0"
 starlette = ">=0.50.0"
@@ -34,7 +35,6 @@ ruff = "^0.16.0"
 isort = ">=5.0.0"
 mypy = ">=1.0.0"
 types-requests = ">=2.28.0"
-httpx = "^0.28.1"
 pyjwt = "^2.11.0"
 
 [tool.poetry.urls]

--- a/tessera_sdk/clients/modela/__init__.py
+++ b/tessera_sdk/clients/modela/__init__.py
@@ -1,5 +1,8 @@
 from .client import ModelaClient
 from .schemas import (
+    ChatCompletionChunk,
+    ChatCompletionChunkChoice,
+    ChatCompletionChunkDelta,
     ChatCompletionRequest,
     ChatCompletionResponse,
     CompletionMessage,
@@ -11,10 +14,13 @@ from .schemas import (
 )
 
 __all__ = [
-    "ModelaClient",
+    "ChatCompletionChunk",
+    "ChatCompletionChunkChoice",
+    "ChatCompletionChunkDelta",
     "ChatCompletionRequest",
     "ChatCompletionResponse",
     "CompletionMessage",
+    "ModelaClient",
     "ScanFileRequest",
     "ScanResponse",
     "SummarizeFileRequest",

--- a/tessera_sdk/clients/modela/client.py
+++ b/tessera_sdk/clients/modela/client.py
@@ -1,10 +1,23 @@
+import json
 import logging
+from collections.abc import AsyncIterator
 from typing import Any, Optional
+
+import httpx
 import requests
 
-from .._base.client import BaseClient
-from ...constants import HTTPMethods
 from ...config import get_settings
+from ...constants import HTTPMethods
+from .._base.client import BaseClient
+from .._base.exceptions import (
+    TesseraAuthenticationError,
+    TesseraClientError,
+    TesseraError,
+    TesseraNotFoundError,
+    TesseraServerError,
+    TesseraValidationError,
+)
+from .schemas.chat_completion_chunk import ChatCompletionChunk
 from .schemas.chat_completion_request import ChatCompletionRequest, CompletionMessage
 from .schemas.chat_completion_response import ChatCompletionResponse
 from .schemas.scan_file_request import ScanFileRequest
@@ -54,6 +67,94 @@ class ModelaClient(BaseClient):
             params={"project_id": project_id},
         )
         return ChatCompletionResponse(**response.json())
+
+    async def stream_complete(
+        self,
+        messages: list[CompletionMessage],
+        model: Optional[str] = None,
+        extra_body: Optional[dict[str, Any]] = None,
+        project_id: str = "*",
+    ) -> AsyncIterator[ChatCompletionChunk]:
+        """Stream a chat completion from Modela as parsed SSE chunks.
+
+        Uses httpx (async) rather than the sync `requests`-based `_make_request`,
+        since streaming a response body isn't supported by the shared BaseClient.
+        """
+        request = ChatCompletionRequest(
+            messages=messages,
+            model=model,
+            extra_body=extra_body,
+        )
+        payload = request.model_dump(mode="json", exclude_none=True)
+        payload["stream"] = True
+
+        headers = {"Content-Type": "application/json"}
+        if self.api_token:
+            headers["Authorization"] = f"Bearer {self.api_token}"
+
+        url = f"{self.base_url}/chat/completions"
+        logger.info(f"Making streaming POST request to {url}")
+
+        async with (
+            httpx.AsyncClient(timeout=self.timeout) as http_client,
+            http_client.stream(
+                "POST",
+                url,
+                json=payload,
+                params={"project_id": project_id},
+                headers=headers,
+            ) as response,
+        ):
+            await self._raise_for_streaming_status(response)
+            async for line in response.aiter_lines():
+                if not line or not line.startswith("data:"):
+                    continue
+                data = line[len("data:") :].strip()
+                if data == "[DONE]":
+                    break
+                try:
+                    chunk_payload = json.loads(data)
+                except ValueError as e:
+                    raise TesseraError(
+                        f"[{self.__class__.__name__}] /chat/completions: "
+                        f"received a malformed streaming chunk: {e}"
+                    ) from e
+                yield ChatCompletionChunk(**chunk_payload)
+
+    async def _raise_for_streaming_status(self, response: httpx.Response) -> None:
+        if response.status_code < 400:
+            return
+        await response.aread()
+        class_name = self.__class__.__name__
+        try:
+            detail = response.json().get("detail")
+        except (ValueError, KeyError, AttributeError):
+            detail = response.text
+        if response.status_code == 401:
+            raise TesseraAuthenticationError(
+                f"[{class_name}] /chat/completions: {detail or 'Authentication failed'}"
+            )
+        if response.status_code == 404:
+            raise TesseraNotFoundError(
+                f"[{class_name}] /chat/completions: {detail or 'Resource not found'}"
+            )
+        if response.status_code == 400:
+            raise TesseraValidationError(
+                f"[{class_name}] /chat/completions: {detail or 'Bad request'}"
+            )
+        if 400 <= response.status_code < 500:
+            raise TesseraClientError(
+                f"[{class_name}] /chat/completions: {response.status_code} {detail}",
+                response.status_code,
+            )
+        if 500 <= response.status_code < 600:
+            raise TesseraServerError(
+                f"[{class_name}] Server error: {response.status_code}",
+                response.status_code,
+            )
+        raise TesseraError(
+            f"[{class_name}] Unexpected status code: {response.status_code}"
+        )
 
     def scan_file(
         self,

--- a/tessera_sdk/clients/modela/schemas/__init__.py
+++ b/tessera_sdk/clients/modela/schemas/__init__.py
@@ -1,3 +1,8 @@
+from .chat_completion_chunk import (
+    ChatCompletionChunk,
+    ChatCompletionChunkChoice,
+    ChatCompletionChunkDelta,
+)
 from .chat_completion_request import ChatCompletionRequest, CompletionMessage
 from .chat_completion_response import (
     ChatCompletionResponse,
@@ -11,10 +16,13 @@ from .summarize_response import SummarizeResponse
 from .summarize_text_request import SummarizeTextRequest
 
 __all__ = [
+    "ChatCompletionChunk",
+    "ChatCompletionChunkChoice",
+    "ChatCompletionChunkDelta",
     "ChatCompletionRequest",
-    "CompletionMessage",
     "ChatCompletionResponse",
     "CompletionChoice",
+    "CompletionMessage",
     "CompletionUsage",
     "ScanFileRequest",
     "ScanResponse",

--- a/tessera_sdk/clients/modela/schemas/chat_completion_chunk.py
+++ b/tessera_sdk/clients/modela/schemas/chat_completion_chunk.py
@@ -1,0 +1,22 @@
+from typing import Optional
+
+from pydantic import BaseModel
+
+
+class ChatCompletionChunkDelta(BaseModel):
+    role: Optional[str] = None
+    content: Optional[str] = None
+
+
+class ChatCompletionChunkChoice(BaseModel):
+    index: int
+    delta: ChatCompletionChunkDelta
+    finish_reason: Optional[str] = None
+
+
+class ChatCompletionChunk(BaseModel):
+    id: str
+    object: str
+    created: int
+    model: str
+    choices: list[ChatCompletionChunkChoice]

--- a/tests/clients/test_modela_streaming.py
+++ b/tests/clients/test_modela_streaming.py
@@ -1,0 +1,164 @@
+import json
+
+import httpx
+import pytest
+
+from tessera_sdk.clients._base.exceptions import (
+    TesseraAuthenticationError,
+    TesseraError,
+)
+from tessera_sdk.clients.modela import ModelaClient
+from tessera_sdk.clients.modela.schemas import CompletionMessage
+
+
+def _sse_body(lines: list[str]) -> bytes:
+    return ("\n".join(lines) + "\n").encode()
+
+
+def _patch_transport(monkeypatch, handler):
+    transport = httpx.MockTransport(handler)
+    real_async_client = httpx.AsyncClient
+
+    def fake_async_client(*args, **kwargs):
+        kwargs["transport"] = transport
+        return real_async_client(*args, **kwargs)
+
+    monkeypatch.setattr(
+        "tessera_sdk.clients.modela.client.httpx.AsyncClient", fake_async_client
+    )
+
+
+CHUNK_1 = {
+    "id": "chatcmpl-1",
+    "object": "chat.completion.chunk",
+    "created": 1,
+    "model": "openai-gpt-4o",
+    "choices": [
+        {
+            "index": 0,
+            "delta": {"role": "assistant", "content": "Hel"},
+            "finish_reason": None,
+        }
+    ],
+}
+CHUNK_2 = {
+    "id": "chatcmpl-1",
+    "object": "chat.completion.chunk",
+    "created": 1,
+    "model": "openai-gpt-4o",
+    "choices": [{"index": 0, "delta": {"content": "lo"}, "finish_reason": None}],
+}
+CHUNK_FINAL = {
+    "id": "chatcmpl-1",
+    "object": "chat.completion.chunk",
+    "created": 1,
+    "model": "openai-gpt-4o",
+    "choices": [{"index": 0, "delta": {}, "finish_reason": "stop"}],
+}
+
+
+@pytest.mark.anyio
+async def test_stream_complete_yields_parsed_chunks_in_order(monkeypatch):
+    sse = _sse_body(
+        [
+            f"data: {json.dumps(CHUNK_1)}",
+            "",
+            f"data: {json.dumps(CHUNK_2)}",
+            "",
+            f"data: {json.dumps(CHUNK_FINAL)}",
+            "",
+            "data: [DONE]",
+            "",
+        ]
+    )
+
+    def handler(request):
+        return httpx.Response(200, content=sse)
+
+    _patch_transport(monkeypatch, handler)
+
+    client = ModelaClient(base_url="https://modela.example.com", api_token="tok")
+    messages = [CompletionMessage(role="user", content="Hi")]
+
+    chunks = [c async for c in client.stream_complete(messages=messages)]
+
+    contents = [c.choices[0].delta.content for c in chunks]
+    assert contents == ["Hel", "lo", None]
+    assert chunks[-1].choices[0].finish_reason == "stop"
+
+
+@pytest.mark.anyio
+async def test_stream_complete_sets_stream_true_and_omits_model_by_default(
+    monkeypatch,
+):
+    captured = {}
+
+    def handler(request):
+        captured["body"] = json.loads(request.content)
+        return httpx.Response(200, content=_sse_body(["data: [DONE]", ""]))
+
+    _patch_transport(monkeypatch, handler)
+
+    client = ModelaClient(base_url="https://modela.example.com", api_token="tok")
+    messages = [CompletionMessage(role="user", content="Hi")]
+
+    async for _ in client.stream_complete(messages=messages):
+        pass
+
+    assert captured["body"]["stream"] is True
+    assert "model" not in captured["body"]
+
+
+@pytest.mark.anyio
+async def test_stream_complete_ends_cleanly_without_done_sentinel(monkeypatch):
+    sse = _sse_body([f"data: {json.dumps(CHUNK_1)}", ""])
+
+    def handler(request):
+        return httpx.Response(200, content=sse)
+
+    _patch_transport(monkeypatch, handler)
+
+    client = ModelaClient(base_url="https://modela.example.com", api_token="tok")
+    messages = [CompletionMessage(role="user", content="Hi")]
+
+    chunks = [c async for c in client.stream_complete(messages=messages)]
+
+    assert len(chunks) == 1
+    assert chunks[0].choices[0].delta.content == "Hel"
+
+
+@pytest.mark.anyio
+async def test_stream_complete_raises_on_malformed_chunk(monkeypatch):
+    sse = _sse_body(["data: {not valid json", ""])
+
+    def handler(request):
+        return httpx.Response(200, content=sse)
+
+    _patch_transport(monkeypatch, handler)
+
+    client = ModelaClient(base_url="https://modela.example.com", api_token="tok")
+    messages = [CompletionMessage(role="user", content="Hi")]
+
+    with pytest.raises(TesseraError):
+        async for _ in client.stream_complete(messages=messages):
+            pass
+
+
+@pytest.mark.anyio
+async def test_stream_complete_raises_on_auth_error(monkeypatch):
+    def handler(request):
+        return httpx.Response(401, json={"detail": "unauthorized"})
+
+    _patch_transport(monkeypatch, handler)
+
+    client = ModelaClient(base_url="https://modela.example.com", api_token="tok")
+    messages = [CompletionMessage(role="user", content="Hi")]
+
+    with pytest.raises(TesseraAuthenticationError):
+        async for _ in client.stream_complete(messages=messages):
+            pass
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"


### PR DESCRIPTION
## Summary
- Adds `ModelaClient.stream_complete()` (async, httpx-based) to consume Modela's existing SSE `/chat/completions` stream, since `BaseClient`/`complete()` are synchronous `requests` and can't stream a response body.
- New `ChatCompletionChunk`/`ChatCompletionChunkChoice`/`ChatCompletionChunkDelta` schemas mirroring Modela's `chat.completion.chunk` shape.
- Moves `httpx` from the dev dependency group to a runtime dependency (it's now needed at import time, not just for tests).

## Test plan
- [x] `poetry run pytest tests/` — 165 passed
- [x] New tests in `tests/clients/test_modela_streaming.py` cover: ordered chunk parsing, `stream=true` + no `model` in the outgoing request, a stream ending without `[DONE]`, a malformed chunk raising `TesseraError`, and a 401 raising `TesseraAuthenticationError`
- [x] `poetry check` passes (lock regenerated)
- [x] `poetry run ruff check` — no new issues in changed files (pre-existing `Optional`-style warnings elsewhere untouched)

Closes #96
